### PR TITLE
fix: use overflowWrap='anywhere' in place of 'break-word' to prevent …

### DIFF
--- a/components/CourseReview.tsx
+++ b/components/CourseReview.tsx
@@ -71,7 +71,7 @@ const CourseReview: FC<CourseReviewProps> = ({ courseData }) => {
                         fontSize={"sm"}
                         textAlign={"left"}
                         mb={2}
-                        overflowWrap={"break-word"}
+                        overflowWrap={"anywhere"}
                     >
                         {review}
                     </Text>


### PR DESCRIPTION
…long words/URLs from breaking layouts