### PR TITLE
Bump TypeScript from 4.9 to 5.9

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint": "7.32.0",
         "eslint-config-next": "^13.0.6",
         "prettier": "2.4.1",
-        "typescript": "^4.9.3"
+        "typescript": "^5.9.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8439,16 +8439,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -14718,9 +14719,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "7.32.0",
     "eslint-config-next": "^13.0.6",
     "prettier": "2.4.1",
-    "typescript": "^4.9.3"
+    "typescript": "^5.9.0"
   },
   "cacheDirectories": [
     ".next/cache"

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -39,6 +39,6 @@
     "eslint-plugin-n": "^15.6.0",
     "eslint-plugin-promise": "^6.1.1",
     "nodemon": "^2.0.20",
-    "typescript": "^4.9.4"
+    "typescript": "^5.9.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -9,12 +13,19 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "ES2020",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "cypress"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "cypress"
+  ]
 }


### PR DESCRIPTION
## Summary
- Bumps `typescript` from `^4.9.x` to `^5.9.0` at the root and in `scraper/`.
- Resolves `TS2590: Expression produces a union type that is too complex to represent` that surfaces against mongoose ≥ 8.17's `Schema<T>` / `Model<T>` generics. Per the mongoose maintainer in [Automattic/mongoose#15632](https://github.com/Automattic/mongoose/issues/15632), this is a TypeScript instantiation-depth bug fixed in TS 5.9.2+; bumping mongoose alone (incl. 9.x) does not resolve it.
- Next.js auto-patched `tsconfig.json` on first build (`moduleResolution: "node" → "bundler"`, `jsx: "preserve" → "react-jsx"`) and updated `next-env.d.ts`. Both are mandatory under modern Next versions.

## Test plan
- [x] `npx tsc --noEmit` at root: clean
- [x] `cd scraper && npx tsc --noEmit`: clean
- [x] `npx next build`: TypeScript step passes (`Compiled successfully`). Prerender step fails locally with `MongooseError: uri parameter ... got "undefined"` — unrelated to this change, caused by absent `MONGO_URI` in the local env.
- [ ] CI build passes against the deployed Mongo URI
- [ ] `npm run dev` smoke test — load `/courses/[courseid]` and confirm API routes still respond

🤖 Generated with [Claude Code](https://claude.com/claude-code)