### PR TITLE
build(deps): bump App Engine to nodejs22 and google-auth-library to v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.22.1",
         "framer-motion": "^6.2.8",
-        "google-auth-library": "^10.9.1",
+        "google-auth-library": "^11.0.0",
         "google-spreadsheet": "^4.1.1",
         "mongoose": "^8.24.1",
         "next": "^16.3.0",
@@ -6746,9 +6746,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
-      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.0.tgz",
+      "integrity": "sha512-WC5gkb2pElGhZKgGx9r799trH3ZUx90ecgIOIMmgiiHS/gzO3r4vvFoQWuKI0QmR2xU5uee2M4hDUxRZDh/x7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -6759,7 +6759,7 @@
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/google-logging-utils": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.22.1",
     "framer-motion": "^6.2.8",
-    "google-auth-library": "^10.9.1",
+    "google-auth-library": "^11.0.0",
     "google-spreadsheet": "^4.1.1",
     "mongoose": "^8.24.1",
     "next": "^16.3.0",

--- a/scraper/app.yaml
+++ b/scraper/app.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs20
+runtime: nodejs22
 instance_class: F1
 automatic_scaling:
   max_instances: 1

--- a/scraper/package-lock.json
+++ b/scraper/package-lock.json
@@ -12,7 +12,7 @@
         "body-parser": "^1.20.6",
         "dotenv": "^16.0.3",
         "express": "^4.22.2",
-        "google-auth-library": "^10.9.1",
+        "google-auth-library": "^11.0.0",
         "google-spreadsheet": "^4.1.1",
         "mongoose": "^8.24.1"
       },
@@ -2630,9 +2630,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
-      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.0.tgz",
+      "integrity": "sha512-WC5gkb2pElGhZKgGx9r799trH3ZUx90ecgIOIMmgiiHS/gzO3r4vvFoQWuKI0QmR2xU5uee2M4hDUxRZDh/x7w==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -2643,7 +2643,7 @@
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/google-logging-utils": {
@@ -6652,9 +6652,9 @@
       }
     },
     "google-auth-library": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
-      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-11.0.0.tgz",
+      "integrity": "sha512-WC5gkb2pElGhZKgGx9r799trH3ZUx90ecgIOIMmgiiHS/gzO3r4vvFoQWuKI0QmR2xU5uee2M4hDUxRZDh/x7w==",
       "requires": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -21,7 +21,7 @@
     "body-parser": "^1.20.6",
     "dotenv": "^16.0.3",
     "express": "^4.22.2",
-    "google-auth-library": "^10.9.1",
+    "google-auth-library": "^11.0.0",
     "google-spreadsheet": "^4.1.1",
     "mongoose": "^8.24.1"
   },


### PR DESCRIPTION
## Summary

Follow-up to #193, which took `google-auth-library` from 9 → 10.9.1. This PR completes the upgrade by clearing the Node floor:

- `scraper/app.yaml`: `runtime: nodejs20` → **`nodejs22`**
- `google-auth-library`: `^10.9.1` → **`^11.0.0`** (root + `scraper/`)

## Why this was split out

`google-auth-library@11.0.0` has a **byte-identical dependency set** to `10.9.1`. The sole difference is `engines.node`:

| Version | `engines.node` |
|---|---|
| 10.9.1 (`legacy-18`) | `>=18` |
| 11.0.0 (`latest`) | `>=22` |

There are **no API changes** between the two. Every breaking API change in this upgrade path (the `Request`/`Headers` revamp, removal of `Transporter`/`options.ts`/`messages.ts`) landed in `10.0.0` and was handled in #193.

So this PR is purely the deployment-runtime change, isolated so the infra risk can be reviewed and rolled back independently of a dependency bump.

## Runtime availability

`nodejs22` is **generally available** on App Engine standard — the Node.js runtime docs currently list Node 26 as the latest (in preview), well past 22.

## Verification

- `npx tsc --noEmit` — passes in **both** root and `scraper/`
- `npm run lint` — passes in **both** root and `scraper/`
- `npm run build` (scraper, swc) — 11 files compiled successfully
- `npm run build` (root, Next) — compiles successfully
- **Runtime interop test** on v11.0.0 under Node v22.21.1 — the `JWT` → `google-spreadsheet@4.1.5` auth path still yields `{"authorization":"Bearer ..."}`
- `npm install` produced **no `EBADENGINE` warnings**

### What can't be verified locally

The App Engine runtime change only takes effect on `gcloud app deploy`. Worth watching the first scraper deploy after this merges.

### Follow-up worth doing

`@types/node` remains at `^18` in both manifests. That affects typechecking only, not the deployed runtime, and was left alone here to keep an infra PR free of unrelated type churn — but it's worth bumping to `^22` separately to match the new runtime.
