### PR TITLE
fix(CourseTable): derive sorted data during render instead of in an effect

### DIFF
--- a/components/CourseTable/CourseTable.tsx
+++ b/components/CourseTable/CourseTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useState } from "react";
 import { ISummary } from "../../scraper/src/models/summary";
 import { Box, Center, Table, useColorModeValue } from "@chakra-ui/react";
 import CourseTableHeader from "./CourseTableHeader";
@@ -45,6 +45,15 @@ const columns: IColumnState[] = [
   },
 ];
 
+function findAccessor(columns: IColumnState[]): [ColumnAccessor, number] {
+  const column = columns.find((column) => column.filter);
+  if (!column) return [ColumnAccessor.code, 0];
+
+  const { accessor, filter } = column;
+  const direction = filter === "asc" ? 1 : -1;
+  return [accessor, direction];
+}
+
 function sortCoursesByColumnAccessor(courseData: ISummary[], columnAccessor: ColumnAccessor, direction: number) {
   const arr = courseData.sort((a: ISummary, b: ISummary) => {
     const x = isNaN(a[columnAccessor] as any) ? a[columnAccessor] : parseFloat(a[columnAccessor]);
@@ -55,29 +64,14 @@ function sortCoursesByColumnAccessor(courseData: ISummary[], columnAccessor: Col
 }
 
 const CourseTable: FC<CourseTableProps> = ({ filter, jsonData }) => {
+  const [columnState, setColumnState] = useState(columns);
+
   const data: ISummary[] = jsonData
     .filter((summary) => summary.tags.some((tag) => filter.includes(tag)))
     .filter((value) => value !== null && value !== undefined);
-  const [columnState, setColumnState] = useState(columns);
-  const [sortedData, setSortedData] = useState<ISummary[]>(data);
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/immutability
-    const [accessor, direction] = findAccessor(columnState);
-    const sortedData = sortCoursesByColumnAccessor(data, accessor, direction);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setSortedData(sortedData);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [columnState, filter, jsonData]);
-
-  function findAccessor(columns: IColumnState[]): [ColumnAccessor, number] {
-    const column = columns.find((column) => column.filter);
-    if (!column) return [ColumnAccessor.code, 0];
-
-    const { accessor, filter } = column;
-    const direction = filter === "asc" ? 1 : -1;
-    return [accessor, direction];
-  }
+  const [accessor, direction] = findAccessor(columnState);
+  const sortedData = sortCoursesByColumnAccessor(data, accessor, direction);
 
   return (
     <Center>


### PR DESCRIPTION
## Summary

Follow-up to #200 (now merged), which surfaced these two rules.

Removes the three `eslint-disable` directives in `CourseTable.tsx` by fixing the underlying pattern rather than suppressing it. Follow-up to the ESLint 9 migration, which surfaced two new eslint-config-next 16 rules here: `react-hooks/immutability` and `react-hooks/set-state-in-effect`.

`sortedData` is a pure function of `jsonData`, `filter` and `columnState`, so it doesn't need state of its own. Sorting now happens during render, which removes:

- the `useEffect`
- the `sortedData` `useState`
- **all three** suppressions — including the *pre-existing* `react-hooks/exhaustive-deps` one, since there's no longer a dependency array to get wrong

`findAccessor` moves to module scope alongside `sortCoursesByColumnAccessor`. It only ever used its own parameter, so it doesn't need redefining per render, and hoisting resolves the immutability rule properly rather than by suppression.

## Verification: A/B against the old implementation

Sorting had **no test coverage** — `table.cy.ts` carries an explicit `//TODO: Test that each column is sortable and sorts correctly`. I'd initially said this couldn't be verified locally; that was wrong. A local MongoDB (Docker) seeded with five courses whose values produce a *distinct* row order per column made it testable via the project's own Cypress suite.

Row order captured in all **nine** sort states — initial, plus both click directions on each of the four columns — under both implementations:

| state | before (effect) | after (derived) | match |
|---|---|---|---|
| initial | 162 261 271 340 361 | 162 261 271 340 361 | ✅ |
| Course Name click1 | 361 340 271 261 162 | 361 340 271 261 162 | ✅ |
| Course Name click2 | 162 261 271 340 361 | 162 261 271 340 361 | ✅ |
| Difficulty click1 | 361 271 162 261 340 | 361 271 162 261 340 | ✅ |
| Difficulty click2 | 340 261 162 271 361 | 340 261 162 271 361 | ✅ |
| Time Commitment click1 | 361 261 162 340 271 | 361 261 162 340 271 | ✅ |
| Time Commitment click2 | 271 340 162 261 361 | 271 340 162 261 361 | ✅ |
| Review Count click1 | 271 340 162 261 361 | 271 340 162 261 361 | ✅ |
| Review Count click2 | 361 261 162 340 271 | 361 261 162 340 271 | ✅ |

**Identical in every state.** The orders also independently match the seeded values — difficulty 1.9 → 4.8, time commitment 6 → 20, review count 5 → 48 all sort correctly in both directions.

## The one behavioural difference

**The first render is now already sorted.** Previously `sortedData` was initialised to the *unsorted* data and only sorted once the effect ran, so mounting the table rendered one intermediate frame of unsorted rows. That intermediate frame is gone.

## Note for future readers

`sortCoursesByColumnAccessor` still sorts **in place**. That stays safe because `data` is rebuilt by `.filter()` on every render — but it would need revisiting if `data` were ever memoised.

## Test results

Against the seeded database:

- ✅ `homepage/table.cy.ts` — 3/3
- ✅ `homepage/cards.cy.ts` — 5/5
- ✅ `courses/courses.cy.ts` — 21/21
- ⚠️ `homepage/filters.cy.ts` — fails **identically before and after** this change (1 passing / 5 failing both ways). The cause is the synthetic seed data having no `Elective`-tagged courses, so those filter menus never render. Not a regression.
- `npm run lint` and `npx tsc --noEmit` — both clean
