### PR TITLE
build(deps-dev): bump @types/node from 18 to 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
-        "@types/node": "^18.11.10",
+        "@types/node": "^22.20.1",
         "@types/react": "^18.3.0",
         "cypress": "^15.17.0",
         "eslint": "^9.39.5",
@@ -2277,13 +2277,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -9980,9 +9980,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.6",
-    "@types/node": "^18.11.10",
+    "@types/node": "^22.20.1",
     "@types/react": "^18.3.0",
     "cypress": "^15.17.0",
     "eslint": "^9.39.5",

--- a/scraper/package-lock.json
+++ b/scraper/package-lock.json
@@ -20,7 +20,7 @@
         "@swc/cli": "^0.8.1",
         "@swc/core": "^1.15.47",
         "@types/express": "^5.0.6",
-        "@types/node": "^18.11.17",
+        "@types/node": "^22.20.1",
         "chokidar": "^5.0.0",
         "concurrently": "^7.6.0",
         "eslint": "^9.39.5",
@@ -1088,10 +1088,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.15.1",
@@ -5518,6 +5522,13 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
@@ -6276,10 +6287,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/qs": {
       "version": "6.15.1",
@@ -9080,6 +9094,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "unicorn-magic": {

--- a/scraper/package.json
+++ b/scraper/package.json
@@ -29,7 +29,7 @@
     "@swc/cli": "^0.8.1",
     "@swc/core": "^1.15.47",
     "@types/express": "^5.0.6",
-    "@types/node": "^18.11.17",
+    "@types/node": "^22.20.1",
     "chokidar": "^5.0.0",
     "concurrently": "^7.6.0",
     "eslint": "^9.39.5",


### PR DESCRIPTION
## Summary

Bumps `@types/node` **18 → 22.20.1** in both workspaces. This is the follow-up promised in #194, which moved `scraper/app.yaml` to `runtime: nodejs22` while the types stayed four majors behind on 18.

## Why 22 and not the latest (26)

Deliberate. The types should describe the runtime **actually in use** — App Engine is on `nodejs22`. Pinning 26 would let code typecheck against APIs the deployed runtime doesn't have, which is the same class of mismatch this PR is fixing, just in the other direction.

## Verification

Checked that the types genuinely moved rather than just the version string in `package.json`. Two APIs absent from `@types/node` 18 now typecheck:

- `process.loadEnvFile` (Node 20.12+)
- `AbortSignal.any` (Node 20.3+)

And confirmed that's a real discriminator by compiling the same snippet against `@types/node` 18 in a scratch project, where it fails:

```
error TS2339: Property 'loadEnvFile' does not exist on type 'Process'.
```

No source changes were needed.

- `npx tsc --noEmit` — passes in **both** root and `scraper/`
- `npm run lint` — passes in **both**
- `npm run build` (scraper, swc) — 11 files, `dist/server.js` at the correct path
- `npm audit` — **0** vulnerabilities in both
- Lockfile formats unchanged: root stays v3, scraper stays v2 with its legacy `dependencies` block