### PR TITLE
build(deps): upgrade to React 19 and react-icons 5

### DIFF
--- a/components/CourseTable/CourseTableHeaderCell.tsx
+++ b/components/CourseTable/CourseTableHeaderCell.tsx
@@ -12,7 +12,7 @@ const CourseTableHeaderCell: FC<CourseTableHeaderCellProps> = ({
     column,
     handleHeaderClick,
 }) => {
-    function handleArrowRender(columnFilter: string | null): JSX.Element {
+    function handleArrowRender(columnFilter: string | null): React.JSX.Element {
         const asc = <TriangleUpIcon w={4} h={4} />;
         const desc = <TriangleDownIcon w={4} h={4} />;
         const inv = <TriangleUpIcon w={4} h={4} visibility={"hidden"} />;

--- a/components/Menus/MenuItemOption.tsx
+++ b/components/Menus/MenuItemOption.tsx
@@ -3,13 +3,13 @@ import { Menu, Span } from "@chakra-ui/react";
 
 interface MenuItemOptionProps {
   title: string;
-  icon: JSX.Element;
+  icon: React.JSX.Element;
   clickHandler: (argument: string) => void;
 }
 
 export interface IMenuOption {
   title: string;
-  icon: JSX.Element;
+  icon: React.JSX.Element;
 }
 
 const MenuItemOption: FC<MenuItemOptionProps> = ({ title, icon, clickHandler }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,15 +20,15 @@
         "mongoose": "^9.9.1",
         "next": "^16.3.0",
         "next-themes": "^0.4.6",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-icons": "^4.3.1"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-icons": "^5.7.0"
       },
       "devDependencies": {
         "@chakra-ui/cli": "^3.36.1",
         "@types/express": "^5.0.6",
         "@types/node": "^22.20.1",
-        "@types/react": "^18.3.0",
+        "@types/react": "^19.2.18",
         "cypress": "^15.17.0",
         "eslint": "^9.39.5",
         "eslint-config-next": "^16.3.0",
@@ -2614,13 +2614,6 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/qs": {
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -2636,13 +2629,12 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
@@ -8773,6 +8765,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -9828,34 +9821,30 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-icons": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
@@ -10188,13 +10177,10 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/scule": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
     "mongoose": "^9.9.1",
     "next": "^16.3.0",
     "next-themes": "^0.4.6",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "react-icons": "^4.3.1"
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "react-icons": "^5.7.0"
   },
   "devDependencies": {
     "@chakra-ui/cli": "^3.36.1",
     "@types/express": "^5.0.6",
     "@types/node": "^22.20.1",
-    "@types/react": "^18.3.0",
+    "@types/react": "^19.2.18",
     "cypress": "^15.17.0",
     "eslint": "^9.39.5",
     "eslint-config-next": "^16.3.0",


### PR DESCRIPTION
Upgrades React to 19 and bundles react-icons 5 alongside it.

```
react        18.3.1  → 19.2.8
react-dom    18.3.1  → 19.2.8
@types/react 18.3.28 → 19.2.18
react-icons  4.12.0  → 5.7.0
```

## Why these two together

react-icons 5.5.0 changed `IconType` to return `React.ReactNode` specifically for React 19 compatibility. `components/CourseCard/Stat.tsx` consumes `IconType`, so upgrading React 19 while staying on react-icons 4 risks a type mismatch there.

## Code changes

Three lines. React 19's `@types/react` removes the global `JSX` namespace in favour of `React.JSX`:

- `components/CourseTable/CourseTableHeaderCell.tsx:15`
- `components/Menus/MenuItemOption.tsx:6,12`

Both files already imported `React`, so no new imports. These were the only three errors `tsc` reported, so the changes were made by hand rather than via `types-react-codemod`.

Everything else in the React 19 breaking-change list was checked and doesn't apply: no `ReactDOM.render`/`hydrate`/`findDOMNode`, no `react-dom/test-utils`, no string refs, no legacy context, no `useRef()` calls needing an argument, and no ref callbacks with implicit returns. The `forwardRef` in `components/ui/tooltip.tsx` is deprecated in 19 but still functional. The `defaultProps` in `components/icons.tsx` is Chakra's `createIcon` option, not React's removed `defaultProps`.

Note this is a real runtime change: the Pages Router takes its React version from `package.json` (unlike the App Router, which bundles its own).

## Verification

- `tsc --noEmit` — clean
- `npm run lint` — clean
- `next build` — TypeScript and compile both pass

Runtime SSR was smoke-tested with a temporary page exercising the changed paths (`Tooltip`'s forwardRef, `Stat`'s `IconType`, `MenuItemOption`, `createIcon` icons, a react-icons import): HTTP 200, zero errors, all content present in the SSR'd HTML. The page was removed afterwards.

## Not verified

`next build` cannot complete in an environment without `MONGODB_URI` — every page uses `getStaticProps` against Mongo, and it fails at static prerender in `scraper/src/mongodb.ts:22`. This is pre-existing and unrelated to this change, but it does mean **a full build and the Cypress e2e suite have not been run**. Worth exercising the Chakra menus and tooltips against real data before merging, since hydration is the least-covered area here.