### PR TITLE
chore: track AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
`next dev` writes the `nextjs-agent-rules` block into `AGENTS.md` on every run, via `node_modules/next/dist/server/lib/generate-agent-files.js`. While the file is untracked it reappears as an uncommitted change after every dev run, so `git status` is never clean. The block itself says committing it is the intended resolution.

`CLAUDE.md` is a one-line pointer at `AGENTS.md`.

Split out from #206 to keep that dependency upgrade focused.